### PR TITLE
Add support for arm64 linux.

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -11,6 +11,8 @@ def probe
                OpenStruct.new(script: 'macos', platform: 'macos_cocoa', ext: 'pkg')
              when /x86_64-linux/
                OpenStruct.new(script: 'linux', platform: 'linux_amd64', ext: 'deb')
+             when /aarch64-linux/
+               OpenStruct.new(script: 'linux', platform: 'linux_arm64', ext: 'deb')
              when /i[3456]86-linux/
                OpenStruct.new(script: 'linux', platform: 'linux_i386', ext: 'deb')
              else


### PR DESCRIPTION
This assumes that

https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_arm64.deb

has been copied to

https://github.com/vovayartsev/wkhtmltopdf-installer-ruby/releases/download/0.12.6-1/wkhtmltox-0.12.6-1.linux_arm64.deb
